### PR TITLE
Catch IndexError when parsing flight data

### DIFF
--- a/appintheair_exporter.py
+++ b/appintheair_exporter.py
@@ -127,7 +127,7 @@ def main():
                     data = parse_flight_data(flight_objects, additional_fields)
                     flights.append(data)
                 except IndexError:
-                    logging.error(f"Error parsing flight data at line {i}")
+                    logging.error(f"Unable to parse flight data at line {i}")
                     continue
             else:
                 parse_next = False

--- a/appintheair_exporter.py
+++ b/appintheair_exporter.py
@@ -122,9 +122,13 @@ def main():
     for i in range(len(finput)):
         if parse_next == True:
             if finput[i].split(":")[0] != "hotels":
-                flight_objects = finput[i].split(";")
-                data = parse_flight_data(flight_objects, additional_fields)
-                flights.append(data)
+                try:
+                    flight_objects = finput[i].split(";")
+                    data = parse_flight_data(flight_objects, additional_fields)
+                    flights.append(data)
+                except IndexError:
+                    logging.error(f"Error parsing flight data at line {i}")
+                    continue
             else:
                 parse_next = False
                 continue


### PR DESCRIPTION
When running the script encountered some entries where AITA had just hotel info and no flights.

For example:
```
Ownership.UNKNOWN;[DATE REMOVED];[DATE REMOVED];None;None;[DATE REMOVED];[DATE REMOVED];None
flights:

hotels:
llm-parsing;[DATE REMOVED];[DATE REMOVED];1;Downtown Camper By Scandic;0;Brunkebergstorg 9;;Stockholm
rental cars:
```


Added a simple error catcher for the script not to crash.

